### PR TITLE
Improve VCOM voltage read command

### DIFF
--- a/getting_started/docs/index.md
+++ b/getting_started/docs/index.md
@@ -62,7 +62,7 @@ You can read out the VCOM voltage by executing the following command in a
 shell (either in GNOME, using the UART console, or via ssh):
 
 ```sh
-cat /sys/module/tps65185_regulator/drivers/i2c\:tps65185/3-0068/regulator/regulator.29/microvolts
+find -L /sys/class/regulator -maxdepth 2 -name "*vcom" -execdir cat microvolts \; 2>/dev/null
 ```
 
 !!!info


### PR DESCRIPTION
The correct microvolts path will not be the same on every device because sysfs is not a stable interface. This commit changes the command given in the documentation to a more robust one. (Thanks to phantomas for the working command)